### PR TITLE
Extend frontend logic with custom hooks for API data fetching

### DIFF
--- a/skillswap_frontend/src/hooks/use-mobile.tsx
+++ b/skillswap_frontend/src/hooks/use-mobile.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/skillswap_frontend/src/hooks/use-toast.ts
+++ b/skillswap_frontend/src/hooks/use-toast.ts
@@ -1,0 +1,194 @@
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "@/components/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/skillswap_frontend/src/hooks/useCategories.ts
+++ b/skillswap_frontend/src/hooks/useCategories.ts
@@ -1,0 +1,61 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface Category {
+  id: number;
+  name: string;
+  description: string;
+  icon: string;
+}
+
+export const useCategories = () => {
+  return useQuery({
+    queryKey: ['categories'],
+    queryFn: async () => {
+      const response = await api.get('/categories/');
+      return response.data;
+    },
+  });
+};
+
+export const useCreateCategory = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (categoryData: Omit<Category, 'id'>) => {
+      const response = await api.post('/categories/', categoryData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+};
+
+export const useUpdateCategory = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ id, ...categoryData }: Partial<Category> & { id: number }) => {
+      const response = await api.put(`/categories/${id}/`, categoryData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+};
+
+export const useDeleteCategory = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const response = await api.delete(`/categories/${id}/`);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+};

--- a/skillswap_frontend/src/hooks/useReviews.ts
+++ b/skillswap_frontend/src/hooks/useReviews.ts
@@ -1,0 +1,111 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface Review {
+  id: number;
+  session: number;
+  reviewer: {
+    id: number;
+    user: {
+      username: string;
+      first_name: string;
+      last_name: string;
+    };
+  };
+  reviewed: {
+    id: number;
+    user: {
+      username: string;
+      first_name: string;
+      last_name: string;
+    };
+  };
+  reviewer_name: string;
+  rating: number;
+  comment: string;
+  created_at: string;
+}
+
+export interface CreateReviewData {
+  session_id: number;
+  reviewed_id: number;
+  rating: number;
+  comment: string;
+}
+
+export const useReviews = () => {
+  return useQuery({
+    queryKey: ['reviews'],
+    queryFn: async () => {
+      const response = await api.get('/reviews/');
+      return response.data;
+    },
+  });
+};
+
+export const useUserReviews = (userId: number) => {
+  return useQuery({
+    queryKey: ['reviews', 'user', userId],
+    queryFn: async () => {
+      const response = await api.get(`/reviews/for_user/?user_id=${userId}`);
+      return response.data;
+    },
+    enabled: !!userId,
+  });
+};
+
+export const useCreateReview = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (reviewData: CreateReviewData) => {
+      const response = await api.post('/reviews/', reviewData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reviews'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+};
+
+export const useSessionReviews = (sessionId: number) => {
+  return useQuery({
+    queryKey: ['reviews', 'session', sessionId],
+    queryFn: async () => {
+      const response = await api.get(`/reviews/?session=${sessionId}`);
+      return response.data;
+    },
+    enabled: !!sessionId,
+  });
+};
+
+export const useUpdateReview = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ id, ...reviewData }: Partial<Review> & { id: number }) => {
+      const response = await api.put(`/reviews/${id}/`, reviewData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reviews'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+};
+
+export const useDeleteReview = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const response = await api.delete(`/reviews/${id}/`);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reviews'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+};

--- a/skillswap_frontend/src/hooks/useSessionMessages.ts
+++ b/skillswap_frontend/src/hooks/useSessionMessages.ts
@@ -1,0 +1,44 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface SessionMessage {
+  id: number;
+  session: number;
+  sender: {
+    id: number;
+    user: {
+      username: string;
+      first_name: string;
+      last_name: string;
+    };
+  };
+  sender_name: string;
+  message: string;
+  created_at: string;
+}
+
+export const useSessionMessages = (sessionId: number) => {
+  return useQuery({
+    queryKey: ['session-messages', sessionId],
+    queryFn: async () => {
+      const response = await api.get(`/sessions/${sessionId}/messages/`);
+      return response.data;
+    },
+    enabled: !!sessionId,
+    refetchInterval: 5000,
+  });
+};
+
+export const useSendMessage = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ sessionId, message }: { sessionId: number; message: string }) => {
+      const response = await api.post(`/sessions/${sessionId}/messages/`, { message });
+      return response.data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['session-messages', variables.sessionId] });
+    },
+  });
+};

--- a/skillswap_frontend/src/hooks/useSessions.ts
+++ b/skillswap_frontend/src/hooks/useSessions.ts
@@ -1,0 +1,149 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface Session {
+  id: number;
+  skill: {
+    id: number;
+    title: string;
+    description: string;
+    category_name: string;
+  };
+  learner: {
+    id: number;
+    user: {
+      username: string;
+      first_name: string;
+      last_name: string;
+    };
+  };
+  mentor: {
+    id: number;
+    user: {
+      username: string;
+      first_name: string;
+      last_name: string;
+    };
+  };
+  scheduled_datetime: string;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED' | 'COMPLETED' | 'CANCELLED';
+  learner_message: string;
+  mentor_response: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LearningSession extends Session {}
+
+export const useSessions = () => {
+  return useQuery({
+    queryKey: ['sessions'],
+    queryFn: async () => {
+      const response = await api.get('/sessions/');
+      return response.data;
+    },
+  });
+};
+
+export const useSessionsAsLearner = () => {
+  return useQuery({
+    queryKey: ['sessions-learner'],
+    queryFn: async () => {
+      const response = await api.get('/sessions/as_learner/');
+      return response.data;
+    },
+  });
+};
+
+export const useSessionsAsMentor = () => {
+  return useQuery({
+    queryKey: ['sessions-mentor'],
+    queryFn: async () => {
+      const response = await api.get('/sessions/as_mentor/');
+      return response.data;
+    },
+  });
+};
+
+export const useCreateSession = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (sessionData: {
+      skill_id: number;
+      scheduled_datetime: string;
+      learner_message?: string;
+    }) => {
+      const response = await api.post('/sessions/', sessionData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions-learner'] });
+    },
+  });
+};
+
+export const useApproveSession = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ sessionId, mentorResponse }: { sessionId: number; mentorResponse?: string }) => {
+      const response = await api.post(`/sessions/${sessionId}/approve/`, { 
+        mentor_response: mentorResponse 
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions-mentor'] });
+    },
+  });
+};
+
+export const useRejectSession = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ sessionId, mentorResponse }: { sessionId: number; mentorResponse?: string }) => {
+      const response = await api.post(`/sessions/${sessionId}/reject/`, { 
+        mentor_response: mentorResponse 
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions-mentor'] });
+    },
+  });
+};
+
+export const useEditSessionTime = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ sessionId, scheduledDatetime }: { sessionId: number; scheduledDatetime: string }) => {
+      const response = await api.post(`/sessions/${sessionId}/edit_time/`, {
+        scheduled_datetime: scheduledDatetime,
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+};
+
+export const useCompleteSession = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (sessionId: number) => {
+      const response = await api.post(`/sessions/${sessionId}/complete/`);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+};

--- a/skillswap_frontend/src/hooks/useSkills.ts
+++ b/skillswap_frontend/src/hooks/useSkills.ts
@@ -1,0 +1,154 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface Category {
+  id: number;
+  name: string;
+  description: string;
+  icon: string;
+}
+
+export interface Skill {
+  id: number;
+  mentor: {
+    id: number;
+    user: {
+      username: string;
+      first_name: string;
+      last_name: string;
+    };
+    user_type: string;
+    bio: string;
+    average_rating: number;
+    review_count: number;
+  };
+  category: number;
+  category_name: string;
+  title: string;
+  description: string;
+  level: 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+  duration_minutes: number;
+  tags: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export const useCategories = () => {
+  return useQuery({
+    queryKey: ['categories'],
+    queryFn: async () => {
+      const response = await api.get('/categories/');
+      return response.data;
+    },
+  });
+};
+
+export const useSkills = (category?: string, level?: string) => {
+  return useQuery({
+    queryKey: ['skills', category, level],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (category) params.append('category', category);
+      if (level) params.append('level', level);
+      
+      const response = await api.get(`/skills/?${params.toString()}`);
+      return response.data;
+    },
+  });
+};
+
+export const useMySkills = () => {
+  return useQuery({
+    queryKey: ['my-skills'],
+    queryFn: async () => {
+      const response = await api.get('/skills/my_skills/');
+      return response.data;
+    },
+  });
+};
+
+export const useCreateSkill = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (skillData: Partial<Skill>) => {
+      const response = await api.post('/skills/', skillData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['skills'] });
+      queryClient.invalidateQueries({ queryKey: ['my-skills'] });
+    },
+  });
+};
+
+export const useUpdateSkill = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ id, ...skillData }: Partial<Skill> & { id: number }) => {
+      const response = await api.put(`/skills/${id}/`, skillData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['skills'] });
+      queryClient.invalidateQueries({ queryKey: ['my-skills'] });
+    },
+  });
+};
+
+export const useDeleteSkill = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await api.delete(`/skills/${id}/`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['skills'] });
+      queryClient.invalidateQueries({ queryKey: ['my-skills'] });
+    },
+  });
+};
+
+export const useUpdateCategory = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (categoryData: { id: number; name: string; description?: string; icon?: string }) => {
+      const { id, ...data } = categoryData;
+      const response = await api.put(`/categories/${id}/`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+};
+
+export const useCreateCategory = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (categoryData: { name: string; description?: string; icon?: string }) => {
+      const response = await api.post('/categories/', categoryData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+};
+
+export const useDeleteCategory = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async (categoryId: number) => {
+      await api.delete(`/categories/${categoryId}/`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+};


### PR DESCRIPTION
This PR extends the previously merged logic layer by adding:
- Custom React hooks for categories, reviews, sessions, skills, and more
- Each hook abstracts API calls and simplifies component integration